### PR TITLE
convert to firebase 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Cutie Cutie <3 !](kitten.jpg)
 
-The project is a **Chat Web App**, groups will be set _randomly_, you will use [Firebase](https://www.firebase.com/) (a Remote Database based on `AJAX` Technology) and some CSS Preprocessors [Less](http://lesscss.org/) & [Sass](http://sass-lang.com/) !
+The project is a **Chat Web App**, groups will be set _randomly_, you will use [Firebase](https://www.firebase.google.com/) (a Remote Database based on `AJAX` Technology) and some CSS Preprocessors [Less](http://lesscss.org/) & [Sass](http://sass-lang.com/) !
 
 What you need, is what you already learn : `HTML`, `CSS`, `Bootstrap`, `JS` and `jQuery` !
 
@@ -53,7 +53,12 @@ Here is the `Javascript` code example give on the official `Firebase` website:
 
 ```javascript
 // Create a connection to your Firebase database
-var ref = new Firebase("https://<YOUR-FIREBASE-APP>.firebaseio.com");
+firebase.initializeApp({
+    apiKey: "<FIREBASE-API-KEY>",
+    authDomain: "<FIREBASE-DOMAIN>.firebaseapp.com",
+    databaseURL: 'https://<FIREBASE-DOMAIN>.firebaseio.com/'
+});
+var myFirebaseRef = firebase.database().ref('/');
 // Save data
 ref.set({ name: "Alex Wolfe" });
 // Listen for realtime changes

--- a/README_FR.md
+++ b/README_FR.md
@@ -2,7 +2,7 @@
 
 ![Cutie Cutie <3 !](kitten.jpg)
 
-Le projet est une **application Web de T'Chat**, les groupes seront définis _aléatoirements_, vous allez utiliser [Firebase](https://www.firebase.com/) (une base de données à distance basée sur la technologie `AJAX`) et certains Préprocesseurs CSS : [Less](http://lesscss.org/) & [Sass](http://sass-lang.com/) !
+Le projet est une **application Web de T'Chat**, les groupes seront définis _aléatoirements_, vous allez utiliser [Firebase](https://www.firebase.google.com/) (une base de données à distance basée sur la technologie `AJAX`) et certains Préprocesseurs CSS : [Less](http://lesscss.org/) & [Sass](http://sass-lang.com/) !
 
 Ce dont vous avez besoin, c'est ce que vous avez déjà appris : `HTML`, `CSS`, `Bootstrap`, `JS` et `jQuery` !
 
@@ -53,7 +53,12 @@ Voici le code d'exemple `Javascript` donné sur le site officiel de `Firebase` :
 
 ```javascript
 // Créé une connexion à votre base de données Firebase
-var ref = new Firebase("https://<YOUR-FIREBASE-APP>.firebaseio.com");
+firebase.initializeApp({
+    apiKey: "<FIREBASE-API-KEY>",
+    authDomain: "<FIREBASE-DOMAIN>.firebaseapp.com",
+    databaseURL: 'https://<FIREBASE-DOMAIN>.firebaseio.com/'
+});
+var myFirebaseRef = firebase.database().ref('/');
 // Enregistre les données
 ref.set({ name: "Alex Wolfe" });
 // Écoute les changements en temps réel

--- a/mdl/index.html
+++ b/mdl/index.html
@@ -34,7 +34,7 @@
 
     <!-- Scripts -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.3/jquery.min.js"></script>
-    <script src="https://cdn.firebase.com/js/client/2.4.2/firebase.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/3.0.2/firebase.js"></script>
     <script src="./script.js"></script>
     <!-- Material Design Light -->
     <script defer src="https://code.getmdl.io/1.1.3/material.min.js"></script>

--- a/mdl/script.js
+++ b/mdl/script.js
@@ -2,7 +2,12 @@ $(document).ready(function() {
     /* ***** BACKEND ***** */
 
     // Create a connection to your Firebase database
-    var myFirebaseRef = new Firebase("https://project-chat-example.firebaseio.com/");
+    firebase.initializeApp({
+        apiKey: "<GET THIS FROM FIREBASE CONSOLE>",
+        authDomain: "project-chat-example.firebaseapp.com",
+        databaseURL: 'https://project-chat-example.firebaseio.com/'
+    });
+    var myFirebaseRef = firebase.database().ref('/');
 
     // Listen for realtime changes
     myFirebaseRef.on('child_added', function(childSnapshot, prevChildKey) {

--- a/raw/index.html
+++ b/raw/index.html
@@ -9,13 +9,18 @@
 
     <!-- Scripts -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.3/jquery.min.js"></script>
-    <script src="https://cdn.firebase.com/js/client/2.4.2/firebase.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/3.0.2/firebase.js"></script>
     <script>
     $(document).ready(function() {
         /* ***** BACKEND ***** */
 
         // Create a connection to your Firebase database
-        var myFirebaseRef = new Firebase("https://project-chat-example.firebaseio.com/");
+        firebase.initializeApp({
+            apiKey: "<GET THIS FROM FIREBASE CONSOLE>",
+            authDomain: "project-chat-example.firebaseapp.com",
+            databaseURL: 'https://project-chat-example.firebaseio.com/'
+        });
+        var myFirebaseRef = firebase.database().ref('/');
 
         // Listen for realtime changes
         myFirebaseRef.on('child_added', function(childSnapshot, prevChildKey) {


### PR DESCRIPTION
This converts the code to be used by newer firebase and allows the usage of other features than were available with older versions of firebase like storing files.
Note that you still need to get your API key from the firebase console to make this work and create new pdf's from the README files.
